### PR TITLE
needs env var now optionally considers content of an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ use needs_env_var::*;
 fn some_test() {
     assert!(1 == 1);
 }
+
+// or if its specified value not matched
+#[needs_env_var(SOMEENVIRONMENTVARIABLE = 1)]
+#[test]
+fn some_test() {
+    assert!(1 == 1);
+}
+
+
+#[needs_env_var(SOMEENVIRONMENTVARIABLE=1)]
+#[test]
+fn some_test() {
+    assert!(1 == 1);
+}
 ```
 
 **Note:** As `needs_env_var` is evaluated at compile time you need to force a re-compilation an environment variable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,23 @@
 use proc_macro::TokenStream;
 use std::env::var;
 
-/// Skip compilation if the environment variable `env_var` is undefined.
-#[proc_macro_attribute]
-pub fn needs_env_var(env_var: TokenStream, item: TokenStream) -> TokenStream {
-    let var_str = env_var.to_string();
-    let exists = var(&var_str).is_ok();
 
-    if !exists{
-        println!("\x1b[93mskipped. environment variable: \"{}\" undefined.\x1b[0m", var_str);
-        return TokenStream::new()
+/// Skip compilation if the environment variable `env_var` is undefined or if its content does not
+/// match the provided value.
+#[proc_macro_attribute]
+pub fn needs_env_var(env_var: TokenStream, input: TokenStream) -> TokenStream {
+    let macro_string = env_var.to_string().replace(" = ", "=");
+    let mut parts = macro_string.split('=');
+
+    let var_str = parts.next().expect("macro needs an environment variable name");
+    let matches  = parts.next();
+
+    let var_content = var(var_str);
+    let exists = var_content.is_ok();
+
+    if !exists || matches.is_some() && matches != var_content.ok().as_deref() {
+        println!("\x1b[93mskipped. environment variable: \"{}\" did not match or was not set.\x1b[0m", var_str);
+        return TokenStream::new();
     }
-    item
+    input
 }


### PR DESCRIPTION
Hi, thanks for the helpful macro!

We're using it over at https://github.com/hansetag/iceberg-catalog to control if some tests run against aws / azure. 

These tests are run in CI and load some secrets, amongst those secrets are the ones used for `needs_env_var`. Unfortunately, these secrets end up as empty env vars instead of not being loaded at all, that causes PRs created from non-maintainers to have failing CI.

In this PR, I've extended `needs_env_var` a bit by an optional matched value, it now allows the following syntax:

```rust
use needs_env_var::*;

#[needs_env_var(SOMEENVIRONMENTVARIABLE)]
#[test]
fn some_test() {
    assert!(1 == 1);
}

#[needs_env_var(SOMEENVIRONMENTVARIABLE = 1)]
#[test]
fn some_test() {
    assert!(1 == 1);
}


#[needs_env_var(SOMEENVIRONMENTVARIABLE=1)]
#[test]
fn some_test() {
    assert!(1 == 1);
}
```

I refrained from pulling in darling since there are no dependencies yet, if you prefer a solution with darling, I'm happy to change the PR.

Kind regards